### PR TITLE
Use Magento 2.2 directory layout

### DIFF
--- a/Platformsh.php
+++ b/Platformsh.php
@@ -16,7 +16,7 @@ class Platformsh
 
     protected $debugMode = false;
 
-    protected $platformReadWriteDirs = ['var/di', 'var/generation', 'app/etc'];
+    protected $platformReadWriteDirs = ['generated', 'app/etc'];
 
     protected $urls = ['unsecure' => [], 'secure' => []];
 


### PR DESCRIPTION
The `generated` directory contains a `code` and a `metadatat` directory that is populated on compile. I guess that's the equivalent of the nonexistent `var/di` and `var/generation` directories.

Ref: #22